### PR TITLE
Added overlay protocol to exchange messages of arbitrary length

### DIFF
--- a/app/bitcoin/client_py/bitcoin.py
+++ b/app/bitcoin/client_py/bitcoin.py
@@ -26,6 +26,8 @@ import stream  # noqa: E402
 
 logging.basicConfig(filename='bitcoin.log', level=logging.DEBUG)
 
+ACK = b'\x42'
+
 
 class dotdict(dict):
     """dot.notation access to dictionary attributes"""
@@ -36,6 +38,44 @@ class dotdict(dict):
 
 # TODO: separate BTC class from the cli
 class Btc:
+    def __init__(self, streamer):
+        self.streamer = streamer
+
+    def exchange_message(self, data: bytes) -> bytes:
+        # Encode the length of the data as a 4-byte big-endian integer
+        length_encoded = len(data).to_bytes(4, 'big')
+
+        # Construct the complete message
+        full_message = length_encoded + data
+        response_data = b''
+
+        # Send the message in chunks of up to 256 bytes
+        for i in range(0, len(full_message), 256):
+            chunk = full_message[i:i+256]
+            response = self.streamer.exchange(chunk)
+
+            # If we're sending the last chunk, the response will be the start of the actual response
+            # Otherwise, the response should be a single byte 0x42.
+            if i + 256 >= len(full_message):
+                response_data = response
+            elif response != ACK:
+                raise ValueError('Unexpected data received before message transmission was complete.')
+
+        if len(response_data) < 4:
+            raise ValueError('Incomplete length received in response.')
+
+        # Extract the expected length of the full response
+        response_length = int.from_bytes(response_data[:4], 'big')
+        response_data = response_data[4:]
+
+        # Continue receiving data until the full response is retrieved
+        while len(response_data) < response_length:
+            chunk = self.streamer.exchange(ACK)  # Request more of the response
+            response_data += chunk
+
+        # Return the complete response
+        return response_data[:response_length]
+
     def get_version_prepare_request(self, args: dotdict):
         get_version = RequestGetVersion()
         message = Request()
@@ -217,11 +257,10 @@ if __name__ == "__main__":
     history = FileHistory('.cli-history')
 
     with stream.get_streamer(args) as streamer:
-
-        btc = Btc()
+        btc = Btc(streamer)
 
         # Run get_version to make sure the app starts
-        streamer.exchange(btc.get_version_prepare_request(dotdict({})))
+        btc.exchange_message(btc.get_version_prepare_request(dotdict({})))
 
         last_command_time = None
         while True:
@@ -244,7 +283,7 @@ if __name__ == "__main__":
             # Get the necessary arguments from input_command_list
             args_dict = dotdict({})
             for item in input_line_list[1:]:
-                key, value = item.split('=')
+                key, value = item.split('=', 1)
                 args_dict[key] = value
 
             if action == "time":
@@ -262,7 +301,7 @@ if __name__ == "__main__":
                 request = prepare_request(args_dict)
 
                 time_start = time.time()
-                data: Optional[bytes] = streamer.exchange(request)
+                data: Optional[bytes] = btc.exchange_message(request)
                 last_command_time = time.time() - time_start
 
                 response = Response()
@@ -277,3 +316,4 @@ if __name__ == "__main__":
                     parse_response(response)
             except Exception as e:
                 print(f"An error occurred: {str(e)}")
+                raise e

--- a/app/bitcoin/client_py/bitcoin.py
+++ b/app/bitcoin/client_py/bitcoin.py
@@ -166,6 +166,7 @@ class Btc:
         get_wallet_address.name = args.get("name", "")
         get_wallet_address.descriptor_template = args.descriptor_template
         get_wallet_address.keys_info.extend(keys_info)
+        get_wallet_address.wallet_hmac = bytes.fromhex(args.get("hmac", ""))
         get_wallet_address.change = int(args.get("change", "0"))
         get_wallet_address.address_index = int(args.get("address_index", "0"))
         message = Request()
@@ -198,6 +199,7 @@ class Btc:
         sign_psbt.name = args.get("name", "")
         sign_psbt.descriptor_template = args.descriptor_template
         sign_psbt.keys_info.extend(keys_info)
+        sign_psbt.wallet_hmac = bytes.fromhex(args.get("hmac", ""))
         sign_psbt.psbt = base64.b64decode(args.psbt)
         message = Request()
         message.sign_psbt.CopyFrom(sign_psbt)
@@ -225,8 +227,8 @@ class ActionArgumentCompleter(Completer):
         "get_master_fingerprint": [],
         "get_extended_pubkey": ["display", "path="],
         "register_wallet": ["name=", "descriptor_template=", "keys_info="],
-        "get_wallet_address": ["name=", "descriptor_template=", "keys_info=", "change=", "address_index="],
-        "sign_psbt": ["name=", "descriptor_template=", "keys_info=", "psbt="],
+        "get_wallet_address": ["name=", "descriptor_template=", "keys_info=", "change=", "address_index=", "hmac="],
+        "sign_psbt": ["name=", "descriptor_template=", "keys_info=", "psbt=", "hmac="],
     }
 
     def get_completions(self, document, complete_event):

--- a/app/bitcoin/src/comm.rs
+++ b/app/bitcoin/src/comm.rs
@@ -1,0 +1,81 @@
+
+use core::{convert::TryInto, cmp::min};
+
+use vanadium_sdk::{xrecv, xsend};
+use alloc::{vec, vec::Vec};
+
+use crate::error::AppError;
+
+// xsend doesn't allow sending 0 bytes; therefore, we just send a
+// a 1-byte acknowledgment when we don't have anything to send. 
+const ACK: u8 = 0x42u8;
+
+pub fn receive_message() -> Result<Vec<u8>, AppError> {
+    let first_chunk = xrecv(256);
+    
+    // If we couldn't even read the length bytes, return an error
+    if first_chunk.len() < 4 {
+        return Err(AppError::new("Failed to read message length"));
+    }
+
+    let length = u32::from_be_bytes(first_chunk[0..4].try_into().expect("Cannot fail")) as usize;
+
+    if first_chunk.len() > 4 + length {
+        return Err(AppError::new("Too many bytes received on the first message"));
+    }    
+
+    // Accumulate the received data (escluding the length prefix) into the result vector.
+    let mut result = first_chunk[4..].to_vec();
+
+    // Calculate remaining bytes to read based on length field and the already read bytes
+    let mut remaining_bytes = length - result.len();    
+    while remaining_bytes > 0 {
+        xsend(&vec![ACK]);
+        let chunk = xrecv(256);
+        if chunk.is_empty() {
+            return Err(AppError::new("Failed to read entire message"));
+        } else if chunk.len() > remaining_bytes {
+            return Err(AppError::new("Too many bytes received"));
+        }
+
+        remaining_bytes -= chunk.len();
+        result.extend(chunk);
+    }
+
+    // At this point, buffer contains the full message including the length field.
+    Ok(result)
+}
+
+pub fn send_message(msg: &[u8]) -> Result<(), AppError> {
+    // Encode the message length in big-endian format
+    let length_be = (msg.len() as u32).to_be_bytes();
+
+    let mut buffer = [0u8; 256];
+
+    // Fill the buffer with the length prefix and as much of the message as fits
+    buffer[..4].copy_from_slice(&length_be);
+    
+    let first_chunk_msg_bytes = min(256 - 4, msg.len());
+    buffer[4..(4 + first_chunk_msg_bytes)].copy_from_slice(&msg[..first_chunk_msg_bytes]);
+    
+    // Send the initial buffer
+    xsend(&buffer[..4 + first_chunk_msg_bytes]);
+
+    let mut total_bytes_sent = first_chunk_msg_bytes;
+
+    // Handle subsequent chunks
+    while total_bytes_sent < msg.len() {
+        let start_idx = total_bytes_sent;
+        let end_idx = min(total_bytes_sent + 256, msg.len());
+
+        let chunk_size = end_idx - start_idx;
+        buffer[..chunk_size].copy_from_slice(&msg[start_idx..end_idx]);
+
+        xrecv(256); // xrecv and xsend must always alternate
+        xsend(&buffer[..chunk_size]);
+
+        total_bytes_sent += chunk_size;
+    }
+
+    Ok(())
+}

--- a/app/bitcoin/src/main.rs
+++ b/app/bitcoin/src/main.rs
@@ -17,6 +17,7 @@ extern crate core;
 #[cfg(test)]
 extern crate base64;
 
+mod comm;
 mod constants;
 mod crypto;
 mod error;
@@ -131,8 +132,7 @@ pub fn main(_: isize, _: *const *const u8) -> isize {
 
     vanadium_sdk::ux::ux_idle();
     loop {
-        // TODO: xrecv currently allocates up to the specified size; we would like to adjust dynamically
-        let buffer = vanadium_sdk::xrecv(2048);
+        let buffer = comm::receive_message().unwrap(); // TODO: what to do on error?
 
         vanadium_sdk::ux::app_loading_start("Handling request...\x00");
 
@@ -141,6 +141,6 @@ pub fn main(_: isize, _: *const *const u8) -> isize {
         vanadium_sdk::ux::app_loading_stop();
         vanadium_sdk::ux::ux_idle();
 
-        vanadium_sdk::xsend(&result);
+        comm::send_message(&result).unwrap(); // TODO: what to do on error?
     }
 }


### PR DESCRIPTION
`xrecv` requires declaring an array of length up to the maximum possible size, which is inconvenient, as we typically have short messages, but we would like to only suffer a small performance degradation for messages that are long.

This adds a protocol on top, that length-encodes a message of arbitrary length, then sends it in chunks of up to 256 bytes. Shorter messages will still require a single xrecv/xsend, while a longer vector is dynamically allocated in case of longer messages.

It could make sense to add this to the Rust sdk, as it's likely useful in many apps.