### PR TITLE
Simplify and generalize merkle proof exchange protocol

### DIFF
--- a/host/merkletree.py
+++ b/host/merkletree.py
@@ -104,23 +104,23 @@ class MerkleTree:
             else:
                 return MerkleTree._path(m - k, entries[k:]) + b"L" + MerkleTree.mth(entries[:k])
 
-    def get_proof(self, addr: int) -> Tuple[Entry, bytes]:
+    def get_proof(self, addr: int) -> Tuple[Entry, bytes, int]:
         m = self._find_index_by_addr(addr)
         assert m != -1
 
         proof = MerkleTree._path(m, self.entries)
         assert len(proof) % 33 == 0
 
-        return Entry(self.entries[m]), proof
+        return Entry(self.entries[m]), proof, len(proof) // 33
 
-    def get_proof_of_last_entry(self) -> Tuple[Entry, bytes]:
+    def get_proof_of_last_entry(self) -> Tuple[Entry, bytes, int]:
         assert len(self.entries) > 0
 
         m = len(self.entries) - 1
         proof = MerkleTree._path(m, self.entries)
         assert len(proof) % 33 == 0
 
-        return Entry(self.entries[m]), proof
+        return Entry(self.entries[m]), proof, len(proof) // 33
 
     def has_addr(self, addr: int) -> bool:
         m = self._find_index_by_addr(addr)

--- a/host/stream_device.py
+++ b/host/stream_device.py
@@ -111,12 +111,14 @@ class DeviceStream:
 
         # 5. add merkle proof if appropriate
         if not page.read_only:
-            entry, proof = self.merkletree.get_proof(request.addr)
+            entry, proof, n_proof_elements = self.merkletree.get_proof(request.addr)
+
             assert entry.addr == request.addr
             assert entry.counter == page.iv
 
             # TODO: handle larger proofs
             assert len(proof) <= 250
+            data += n_proof_elements.to_bytes(1, "big")
             data += proof
  
         apdu = self.client.exchange(0x01, data=data)
@@ -135,19 +137,20 @@ class DeviceStream:
         # 3. commit page and send merkle proof
         if self.merkletree.has_addr(request.addr):
             # proof of previous value
-            entry, proof = self.merkletree.get_proof(request.addr)
+            entry, proof, n_proof_elements = self.merkletree.get_proof(request.addr)
             assert entry.addr == request.addr
             assert entry.counter + 1 == request.iv
         else:
             # proof of last entry
-            entry, proof = self.merkletree.get_proof_of_last_entry()
+            entry, proof, n_proof_elements = self.merkletree.get_proof_of_last_entry()
 
         self._write_page(request.addr, page_data, request.mac, request.iv)
 
         # TODO: handle larger proofs
         assert len(proof) <= 250
 
-        return self.client.exchange(0x02, data=proof)
+        data = n_proof_elements.to_bytes(1, "big") + proof
+        return self.client.exchange(0x02, data=data)
 
     def handle_send_buffer(self, data: bytes) -> bool:
         logger.debug(f"got buffer {data!r}")

--- a/vm/src/merkle.h
+++ b/vm/src/merkle.h
@@ -38,3 +38,16 @@ bool merkle_verify_proof(const struct entry_s *entry, const struct proof_s *proo
 void init_merkle_tree(const uint8_t *root_hash_init,
                       size_t merkle_tree_size,
                       const struct entry_s *last_entry_init);
+
+
+// Computes the hash of an entry (leaf)
+void init_digest(uint8_t digest[static CX_SHA256_SIZE], const struct entry_s *entry);
+
+// Given a number of elements of a Merkle proof, computes the hash of the internal node obtained
+// by processing the proof element. If the proof is complete, then it's the Merkle root.
+// Return -1 if proof_bytes_len is not a multiple of sizeof(struct proof_s), otherwise returns
+// the number of proof elements processed: proof_bytes_len / sizeof(struct proof_s).
+int update_with_partial_proof(uint8_t digest[static CX_SHA256_SIZE], uint8_t *proof_bytes, size_t proof_bytes_len);
+
+// Given a digest, checks if it matches the current Merkle root.
+bool compare_merkle_root_with_digest(uint8_t digest[static CX_SHA256_SIZE])


### PR DESCRIPTION
Adding a 1-byte length makes it easier to check the proof.

TODO: allow splitting the proof in multiple messages if too long